### PR TITLE
add type parameter for comparable keys

### DIFF
--- a/lru.go
+++ b/lru.go
@@ -3,30 +3,30 @@ package tinylfu
 import "github.com/dgryski/go-tinylfu/internal/list"
 
 // Cache is an LRU cache.  It is not safe for concurrent access.
-type lruCache[V any] struct {
-	data map[string]*list.Element[*slruItem[V]]
+type lruCache[K comparable, V any] struct {
+	data map[K]*list.Element[*slruItem[K, V]]
 	cap  int
-	ll   *list.List[*slruItem[V]]
+	ll   *list.List[*slruItem[K, V]]
 }
 
-func newLRU[V any](cap int, data map[string]*list.Element[*slruItem[V]]) *lruCache[V] {
-	return &lruCache[V]{
+func newLRU[K comparable, V any](cap int, data map[K]*list.Element[*slruItem[K, V]]) *lruCache[K, V] {
+	return &lruCache[K, V]{
 		data: data,
 		cap:  cap,
-		ll:   list.New[*slruItem[V]](),
+		ll:   list.New[*slruItem[K, V]](),
 	}
 }
 
 // Get returns a value from the cache
-func (lru *lruCache[V]) get(v *list.Element[*slruItem[V]]) {
+func (lru *lruCache[K, V]) get(v *list.Element[*slruItem[K, V]]) {
 	lru.ll.MoveToFront(v)
 }
 
 // Set sets a value in the cache
-func (lru *lruCache[V]) add(newitem slruItem[V]) (oitem slruItem[V], evicted bool) {
+func (lru *lruCache[K, V]) add(newitem slruItem[K, V]) (oitem slruItem[K, V], evicted bool) {
 	if lru.ll.Len() < lru.cap {
 		lru.data[newitem.key] = lru.ll.PushFront(&newitem)
-		return slruItem[V]{}, false
+		return slruItem[K, V]{}, false
 	}
 
 	// reuse the tail item
@@ -45,12 +45,12 @@ func (lru *lruCache[V]) add(newitem slruItem[V]) (oitem slruItem[V], evicted boo
 }
 
 // Len returns the total number of items in the cache
-func (lru *lruCache[V]) Len() int {
+func (lru *lruCache[K, V]) Len() int {
 	return len(lru.data)
 }
 
 // Remove removes an item from the cache, returning the item and a boolean indicating if it was found
-func (lru *lruCache[V]) Remove(key string) (V, bool) {
+func (lru *lruCache[K, V]) Remove(key K) (V, bool) {
 	v, ok := lru.data[key]
 	if !ok {
 		return *new(V), false

--- a/s2lru.go
+++ b/s2lru.go
@@ -2,32 +2,32 @@ package tinylfu
 
 import "github.com/dgryski/go-tinylfu/internal/list"
 
-type slruItem[V any] struct {
+type slruItem[K comparable, V any] struct {
 	listid int
-	key    string
+	key    K
 	value  V
 	keyh   uint64
 }
 
 // Cache is an LRU cache.  It is not safe for concurrent access.
-type slruCache[V any] struct {
-	data           map[string]*list.Element[*slruItem[V]]
+type slruCache[K comparable, V any] struct {
+	data           map[K]*list.Element[*slruItem[K, V]]
 	onecap, twocap int
-	one, two       *list.List[*slruItem[V]]
+	one, two       *list.List[*slruItem[K, V]]
 }
 
-func newSLRU[V any](onecap, twocap int, data map[string]*list.Element[*slruItem[V]]) *slruCache[V] {
-	return &slruCache[V]{
+func newSLRU[K comparable, V any](onecap, twocap int, data map[K]*list.Element[*slruItem[K, V]]) *slruCache[K, V] {
+	return &slruCache[K, V]{
 		data:   data,
 		onecap: onecap,
-		one:    list.New[*slruItem[V]](),
+		one:    list.New[*slruItem[K, V]](),
 		twocap: twocap,
-		two:    list.New[*slruItem[V]](),
+		two:    list.New[*slruItem[K, V]](),
 	}
 }
 
 // get updates the cache data structures for a get
-func (slru *slruCache[V]) get(v *list.Element[*slruItem[V]]) {
+func (slru *slruCache[K, V]) get(v *list.Element[*slruItem[K, V]]) {
 	item := v.Value
 
 	// already on list two?
@@ -66,7 +66,7 @@ func (slru *slruCache[V]) get(v *list.Element[*slruItem[V]]) {
 }
 
 // Set sets a value in the cache
-func (slru *slruCache[V]) add(newitem slruItem[V]) {
+func (slru *slruCache[K, V]) add(newitem slruItem[K, V]) {
 
 	newitem.listid = 1
 
@@ -87,7 +87,7 @@ func (slru *slruCache[V]) add(newitem slruItem[V]) {
 	slru.one.MoveToFront(e)
 }
 
-func (slru *slruCache[V]) victim() *slruItem[V] {
+func (slru *slruCache[K, V]) victim() *slruItem[K, V] {
 
 	if slru.Len() < slru.onecap+slru.twocap {
 		return nil
@@ -99,12 +99,12 @@ func (slru *slruCache[V]) victim() *slruItem[V] {
 }
 
 // Len returns the total number of items in the cache
-func (slru *slruCache[V]) Len() int {
+func (slru *slruCache[K, V]) Len() int {
 	return slru.one.Len() + slru.two.Len()
 }
 
 // Remove removes an item from the cache, returning the item and a boolean indicating if it was found
-func (slru *slruCache[V]) Remove(key string) (V, bool) {
+func (slru *slruCache[K, V]) Remove(key K) (V, bool) {
 	v, ok := slru.data[key]
 	if !ok {
 		return *new(V), false

--- a/tinylfu_test.go
+++ b/tinylfu_test.go
@@ -1,9 +1,15 @@
 package tinylfu
 
-import "testing"
+import (
+	"hash/maphash"
+	"testing"
+)
 
 func TestAddAlreadyInCache(t *testing.T) {
-	c := New[string](100, 10000)
+	s := maphash.MakeSeed()
+	c := New[string, string](100, 10000, func(k string) uint64 {
+		return maphash.String(s, k)
+	})
 
 	c.Add("foo", "bar")
 
@@ -24,7 +30,10 @@ var SinkString string
 var SinkBool bool
 
 func BenchmarkGet(b *testing.B) {
-	t := New[string](64, 640)
+	s := maphash.MakeSeed()
+	t := New[string, string](64, 640, func(k string) uint64 {
+		return maphash.String(s, k)
+	})
 	key := "some arbitrary key"
 	val := "some arbitrary value"
 	t.Add(key, val)


### PR DESCRIPTION
This PR modifies the `T` type to accept a type parameter for the keys in order to support any comparable type (not only string keys).

One key change here is we need to add the hash function as a parameter to `New`, because there is no generic hash system in Go (yet).

I considered adding a package to this repo with helper hash functions, for example:
```go
package maphashfunc
...
func String(s maphash.Seed) func(string) uint64 {
  return func(v string) uint64 { return maphash.String(s, v) }
}
```
But it seemed maybe a bit out of scope? For now I simply modified the tests, which can serve as examples of how to configure the hash function. Let me know if you have any suggestions on the topic.