### PR TITLE
add drop callback for evicted items

### DIFF
--- a/lru.go
+++ b/lru.go
@@ -33,8 +33,6 @@ func (lru *lruCache[K, V]) add(newitem slruItem[K, V]) (oitem slruItem[K, V], ev
 	e := lru.ll.Back()
 	item := e.Value
 
-	delete(lru.data, item.key)
-
 	oitem = *item
 	*item = newitem
 

--- a/s2lru.go
+++ b/s2lru.go
@@ -65,7 +65,7 @@ func (slru *slruCache[K, V]) get(v *list.Element[*slruItem[K, V]]) {
 	slru.two.MoveToFront(back)
 }
 
-// Set sets a value in the cache
+// add adds a value to the cache
 func (slru *slruCache[K, V]) add(newitem slruItem[K, V]) (oitem slruItem[K, V], evicted bool) {
 
 	newitem.listid = 1
@@ -78,8 +78,6 @@ func (slru *slruCache[K, V]) add(newitem slruItem[K, V]) (oitem slruItem[K, V], 
 	// reuse the tail item
 	e := slru.one.Back()
 	item := e.Value
-
-	delete(slru.data, item.key)
 
 	oitem = *item
 	*item = newitem

--- a/s2lru.go
+++ b/s2lru.go
@@ -66,7 +66,7 @@ func (slru *slruCache[K, V]) get(v *list.Element[*slruItem[K, V]]) {
 }
 
 // Set sets a value in the cache
-func (slru *slruCache[K, V]) add(newitem slruItem[K, V]) {
+func (slru *slruCache[K, V]) add(newitem slruItem[K, V]) (oitem slruItem[K, V], evicted bool) {
 
 	newitem.listid = 1
 
@@ -81,10 +81,12 @@ func (slru *slruCache[K, V]) add(newitem slruItem[K, V]) {
 
 	delete(slru.data, item.key)
 
+	oitem = *item
 	*item = newitem
 
 	slru.data[item.key] = e
 	slru.one.MoveToFront(e)
+	return oitem, true
 }
 
 func (slru *slruCache[K, V]) victim() *slruItem[K, V] {

--- a/tinylfu.go
+++ b/tinylfu.go
@@ -39,7 +39,6 @@ func New[K comparable, V any](size int, samples int, hash func(K) uint64, option
 	slruSize := size - lruSize
 	if slruSize < 1 {
 		slruSize = 1
-
 	}
 	slru20 := slruSize / 5
 	if slru20 < 1 {
@@ -128,8 +127,6 @@ func (t *T[K, V]) Add(key K, val V) {
 		return
 	}
 
-	t.evict(oitem.key, oitem.value)
-
 	// estimate count of what will be evicted from slru
 	victim := t.slru.victim()
 	if victim == nil {
@@ -140,6 +137,7 @@ func (t *T[K, V]) Add(key K, val V) {
 	}
 
 	if !t.bouncer.allow(oitem.keyh) {
+		t.evict(oitem.key, oitem.value)
 		return
 	}
 
@@ -147,6 +145,7 @@ func (t *T[K, V]) Add(key K, val V) {
 	ocount := t.c.estimate(oitem.keyh)
 
 	if ocount < vcount {
+		t.evict(oitem.key, oitem.value)
 		return
 	}
 

--- a/tinylfu.go
+++ b/tinylfu.go
@@ -15,11 +15,18 @@ type T[K comparable, V any] struct {
 	slru    *slruCache[K, V]
 	data    map[K]*list.Element[*slruItem[K, V]]
 	hash    func(K) uint64
+	drop    func(K, V)
 }
 
-func New[K comparable, V any](size int, samples int, hash func(K) uint64) *T[K, V] {
-
+func New[K comparable, V any](size int, samples int, hash func(K) uint64, drop func(K, V)) *T[K, V] {
 	const lruPct = 1
+
+	if hash == nil {
+		panic("tinylfu: hash function is required")
+	}
+	if drop == nil {
+		panic("tinylfu: drop function is required")
+	}
 
 	lruSize := (lruPct * size) / 100
 	if lruSize < 1 {
@@ -49,6 +56,7 @@ func New[K comparable, V any](size int, samples int, hash func(K) uint64) *T[K, 
 		slru: newSLRU(slru20, slruSize-slru20, data),
 
 		hash: hash,
+		drop: drop,
 	}
 }
 
@@ -106,10 +114,14 @@ func (t *T[K, V]) Add(key K, val V) {
 		return
 	}
 
+	t.drop(oitem.key, oitem.value)
+
 	// estimate count of what will be evicted from slru
 	victim := t.slru.victim()
 	if victim == nil {
-		t.slru.add(oitem)
+		if oitem, evicted := t.slru.add(oitem); evicted {
+			t.drop(oitem.key, oitem.value)
+		}
 		return
 	}
 
@@ -124,5 +136,7 @@ func (t *T[K, V]) Add(key K, val V) {
 		return
 	}
 
-	t.slru.add(oitem)
+	if oitem, evicted := t.slru.add(oitem); evicted {
+		t.drop(oitem.key, oitem.value)
+	}
 }

--- a/tinylfu_test.go
+++ b/tinylfu_test.go
@@ -7,10 +7,9 @@ import (
 
 func TestAddAlreadyInCache(t *testing.T) {
 	s := maphash.MakeSeed()
-	c := New[string, string](100, 10000,
-		func(k string) uint64 { return maphash.String(s, k) },
-		func(k, v string) {},
-	)
+	c := New[string, string](100, 10000, func(k string) uint64 {
+		return maphash.String(s, k)
+	})
 
 	c.Add("foo", "bar")
 
@@ -32,10 +31,9 @@ var SinkBool bool
 
 func BenchmarkGet(b *testing.B) {
 	s := maphash.MakeSeed()
-	t := New[string, string](64, 640,
-		func(k string) uint64 { return maphash.String(s, k) },
-		func(k, v string) {},
-	)
+	t := New[string, string](64, 640, func(k string) uint64 {
+		return maphash.String(s, k)
+	})
 	key := "some arbitrary key"
 	val := "some arbitrary value"
 	t.Add(key, val)

--- a/tinylfu_test.go
+++ b/tinylfu_test.go
@@ -33,13 +33,10 @@ func TestOnEvict(t *testing.T) {
 	}
 
 	var evicted []item
-	var expected = []item{
-		{k: "A", v: "1"},
-		{k: "B", v: "2"},
-	}
+	var expected = []item{{k: "B", v: "2"}}
 
 	s := maphash.MakeSeed()
-	c := New[string, string](64, 640,
+	c := New[string, string](2, 20,
 		func(k string) uint64 {
 			return maphash.String(s, k)
 		},
@@ -63,17 +60,11 @@ func TestOnReplace(t *testing.T) {
 	}
 
 	var evicted []item
-	var expectedEvicted = []item{
-		{k: "A", v: "1"},
-	}
-
 	var replaced []item
-	var expectedReplaced = []item{
-		{k: "A", v: "1"},
-	}
+	var expected = []item{{k: "A", v: "1"}}
 
 	s := maphash.MakeSeed()
-	c := New[string, string](64, 640,
+	c := New[string, string](10, 20,
 		func(k string) uint64 {
 			return maphash.String(s, k)
 		},
@@ -89,11 +80,11 @@ func TestOnReplace(t *testing.T) {
 	c.Add("B", "2")
 	c.Add("A", "3")
 
-	if !slices.Equal(evicted, expectedEvicted) {
-		t.Errorf("evicted=%+v, expected=%+v", evicted, expectedEvicted)
+	if !slices.Equal(evicted, nil) {
+		t.Errorf("evicted=%+v, expected=%+v", evicted, nil)
 	}
-	if !slices.Equal(replaced, expectedReplaced) {
-		t.Errorf("replaced=%+v, expected=%+v", replaced, expectedReplaced)
+	if !slices.Equal(replaced, expected) {
+		t.Errorf("replaced=%+v, expected=%+v", replaced, expected)
 	}
 }
 

--- a/tinylfu_test.go
+++ b/tinylfu_test.go
@@ -2,6 +2,7 @@ package tinylfu
 
 import (
 	"hash/maphash"
+	"slices"
 	"testing"
 )
 
@@ -23,6 +24,76 @@ func TestAddAlreadyInCache(t *testing.T) {
 	val, _ = c.Get("foo")
 	if val != "baz" {
 		t.Errorf("c.Get(foo)=%q, want %q", val, "baz")
+	}
+}
+
+func TestOnEvict(t *testing.T) {
+	type item struct {
+		k, v string
+	}
+
+	var evicted []item
+	var expected = []item{
+		{k: "A", v: "1"},
+		{k: "B", v: "2"},
+	}
+
+	s := maphash.MakeSeed()
+	c := New[string, string](64, 640,
+		func(k string) uint64 {
+			return maphash.String(s, k)
+		},
+		OnEvict(func(k, v string) {
+			evicted = append(evicted, item{k, v})
+		}),
+	)
+
+	c.Add("A", "1")
+	c.Add("B", "2")
+	c.Add("C", "3")
+
+	if !slices.Equal(evicted, expected) {
+		t.Errorf("evicted=%+v, expected=%+v", evicted, expected)
+	}
+}
+
+func TestOnReplace(t *testing.T) {
+	type item struct {
+		k, v string
+	}
+
+	var evicted []item
+	var expectedEvicted = []item{
+		{k: "A", v: "1"},
+	}
+
+	var replaced []item
+	var expectedReplaced = []item{
+		{k: "A", v: "1"},
+	}
+
+	s := maphash.MakeSeed()
+	c := New[string, string](64, 640,
+		func(k string) uint64 {
+			return maphash.String(s, k)
+		},
+		OnEvict(func(k, v string) {
+			evicted = append(evicted, item{k, v})
+		}),
+		OnReplace(func(k, v string) {
+			replaced = append(replaced, item{k, v})
+		}),
+	)
+
+	c.Add("A", "1")
+	c.Add("B", "2")
+	c.Add("A", "3")
+
+	if !slices.Equal(evicted, expectedEvicted) {
+		t.Errorf("evicted=%+v, expected=%+v", evicted, expectedEvicted)
+	}
+	if !slices.Equal(replaced, expectedReplaced) {
+		t.Errorf("replaced=%+v, expected=%+v", replaced, expectedReplaced)
 	}
 }
 

--- a/tinylfu_test.go
+++ b/tinylfu_test.go
@@ -7,9 +7,10 @@ import (
 
 func TestAddAlreadyInCache(t *testing.T) {
 	s := maphash.MakeSeed()
-	c := New[string, string](100, 10000, func(k string) uint64 {
-		return maphash.String(s, k)
-	})
+	c := New[string, string](100, 10000,
+		func(k string) uint64 { return maphash.String(s, k) },
+		func(k, v string) {},
+	)
 
 	c.Add("foo", "bar")
 
@@ -31,9 +32,10 @@ var SinkBool bool
 
 func BenchmarkGet(b *testing.B) {
 	s := maphash.MakeSeed()
-	t := New[string, string](64, 640, func(k string) uint64 {
-		return maphash.String(s, k)
-	})
+	t := New[string, string](64, 640,
+		func(k string) uint64 { return maphash.String(s, k) },
+		func(k, v string) {},
+	)
 	key := "some arbitrary key"
 	val := "some arbitrary value"
 	t.Add(key, val)


### PR DESCRIPTION
This PR adds a `drop` callback to the constructor, this is useful when items stored in the cache hold resources that need to be explicitly released.

Fixes #2 
