### PR TITLE
feat: add Remove(key K) method to TinyLFU cache

### DIFF
--- a/tinylfu.go
+++ b/tinylfu.go
@@ -154,4 +154,19 @@ func (t *T[K, V]) Add(key K, val V) {
 	}
 }
 
+// Remove removes an item from the cache, returning the value and a boolean indicating if it was found
+func (t *T[K, V]) Remove(key K) (V, bool) {
+	val, ok := t.data[key]
+	if !ok {
+		return *new(V), false
+	}
+
+	item := val.Value
+
+	if item.listid == 0 {
+		return t.lru.Remove(key)
+	}
+	return t.slru.Remove(key)
+}
+
 func ignore[K, V any](K, V) {}

--- a/tinylfu_test.go
+++ b/tinylfu_test.go
@@ -106,6 +106,38 @@ func TestNoCachePollution(t *testing.T) {
 var SinkString string
 var SinkBool bool
 
+func TestRemove(t *testing.T) {
+	s := maphash.MakeSeed()
+	c := New[string, string](10, 100, func(k string) uint64 {
+		return maphash.String(s, k)
+	})
+
+	// Test removing non-existent key
+	_, ok := c.Remove("nonexistent")
+	if ok {
+		t.Error("Remove(nonexistent) should return false")
+	}
+
+	// Add and remove a key
+	c.Add("foo", "bar")
+	val, ok := c.Remove("foo")
+	if !ok || val != "bar" {
+		t.Errorf("Remove(foo)=%q, %v; want bar, true", val, ok)
+	}
+
+	// Verify key is gone
+	_, ok = c.Get("foo")
+	if ok {
+		t.Error("Get(foo) should return false after Remove")
+	}
+
+	// Test removing again returns false
+	_, ok = c.Remove("foo")
+	if ok {
+		t.Error("Remove(foo) should return false after already removed")
+	}
+}
+
 func BenchmarkGet(b *testing.B) {
 	s := maphash.MakeSeed()
 	t := New[string, string](64, 640, func(k string) uint64 {


### PR DESCRIPTION
Adds a Remove method to allow users to actively remove keys from the cache. The method returns the removed value and true if the key was found, or the zero value and false otherwise.

Fixes #12